### PR TITLE
OSX support for abitti_dlimg.sh, abitti_createvm.sh and abitti_export_vbktp.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ www.abitti.fi). The scripts are unofficial and they might be outdated.
 
 These scripts create Abitti virtual machines to Oracle VirtualBox
 installation. Execute the script in a directory containing server and
-test-taker images (`ktp.dd` and `koe.dd`). Linux hosts may use
+test-taker images (`ktp.dd` and `koe.dd`). Linux and Mac OSX hosts may use
 `abitti_dlimg.sh` to download images. Windows hosts can use official AbittiUSB
 to do the same. The images are located in `PROFILE/AppData/Local/YtlDigabi/`.
 
- * `abitti_createvm.sh` Create Abitti VMs on Linux host. The script must be executed in the directory where the images exist.
+ * `abitti_createvm.sh` Create Abitti VMs on Linux and Mac OSX host. The script must be executed in the directory where the images exist.
  * `abitti_createvm.bat` Create Abitti VMs on Windows host. The script looks disk images from the AbittiUSB location so there is no need to copy images. If the images are not present in profile they are searched from the current directory.
 
 ## Run Abitti server in VirtualBox for a local exam network

--- a/abitti_createvm.sh
+++ b/abitti_createvm.sh
@@ -1,5 +1,26 @@
-#!/bin/sh
-VBM=/usr/bin/VBoxManage
+#!/usr/bin/env bash
+
+if [ "$(uname)" == "Darwin" ]; then
+    # Running on Mac OSX
+    VBM=/Applications/VirtualBox.app/Contents/Resources/VirtualBoxVM.app/Contents/MacOS/VBoxManage
+    if [ ! -f $VBM ]; then
+        echo "You seem to be running Mac OSX operating system."
+        echo "VirtualBox's VBoxManage command line tool was not found at:"
+        echo $VBM
+        echo "Exiting"
+        exit
+    fi
+else
+    # Running on Linux
+    VBM=/usr/bin/VBoxManage
+    if [ ! -f $VBM ]; then
+        echo "You seem to be running Linux operating system."
+        echo "VirtualBox's VBoxManage command line tool was not found at:"
+        echo $VBM
+        echo "Exiting"
+        exit
+    fi
+fi
 
 echo "Shutdown existing VM:s"
 ${VBM} controlvm Abitti-KOE poweroff 

--- a/abitti_dlimg.sh
+++ b/abitti_dlimg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Downloads and unpacks Abitti (www.abitti.fi) disk images.
 #
@@ -7,6 +7,7 @@
 # This script is not supported by Matriculation Examination Board of
 # Finland. The download URLs may change without any notice. For
 # supported tools see www.abitti.fi.
+
 
 FLAVOUR=prod
 if type 'md5sum' > /dev/null 2>&1; then
@@ -32,12 +33,20 @@ report_warning() {
 download_and_check() {
 	TAG=$1
 	
-	wget -c http://static.abitti.fi/usbimg/${FLAVOUR}/${VERSION}/${TAG}.zip.md5
+	if [ "$(uname)" == "Darwin" ]; then
+		curl -O http://static.abitti.fi/usbimg/${FLAVOUR}/${VERSION}/${TAG}.zip.md5 # Mac OSX
+	else
+		wget -c http://static.abitti.fi/usbimg/${FLAVOUR}/${VERSION}/${TAG}.zip.md5 # Linux
+	fi
 	if [ $? -ne 0 ]; then
 		report_error "Failed to download image '${TAG}' MD5: $?"
 	fi
 	
-	wget -c http://static.abitti.fi/usbimg/${FLAVOUR}/${VERSION}/${TAG}.zip
+	if [ "$(uname)" == "Darwin" ]; then
+		curl -O http://static.abitti.fi/usbimg/${FLAVOUR}/${VERSION}/${TAG}.zip # Mac OSX
+	else
+		wget -c http://static.abitti.fi/usbimg/${FLAVOUR}/${VERSION}/${TAG}.zip.md5 # Linux
+	fi
 	if [ $? -ne 0 ]; then
 		report_error "Failed to download image '${TAG}': $?"
 	fi
@@ -58,7 +67,11 @@ download_and_check() {
 }
 
 
-VERSION=`wget http://static.abitti.fi/usbimg/${FLAVOUR}/latest.txt -q -O-`
+if [ "$(uname)" == "Darwin" ]; then
+	VERSION=`curl http://static.abitti.fi/usbimg/${FLAVOUR}/latest.txt`
+else
+	VERSION=`wget http://static.abitti.fi/usbimg/${FLAVOUR}/latest.txt -q -O-`
+fi
 
 if [ "${VERSION}" = "" ]; then
 	report_error "Could not get latest Abitti version for flavour '${FLAVOUR}'"

--- a/abitti_export_vbktp.sh
+++ b/abitti_export_vbktp.sh
@@ -1,5 +1,26 @@
-#!/bin/sh
-VBM=/usr/bin/VBoxManage
+#!/usr/bin/env bash
+
+if [ "$(uname)" == "Darwin" ]; then
+    # Running on Mac OSX
+    VBM=/Applications/VirtualBox.app/Contents/Resources/VirtualBoxVM.app/Contents/MacOS/VBoxManage
+    if [ ! -f $VBM ]; then
+        echo "You seem to be running Mac OSX operating system."
+        echo "VirtualBox's VBoxManage command line tool was not found at:"
+        echo $VBM
+        echo "Exiting"
+        exit
+    fi
+else
+    # Running on Linux
+    VBM=/usr/bin/VBoxManage
+    if [ ! -f $VBM ]; then
+        echo "You seem to be running Linux operating system."
+        echo "VirtualBox's VBoxManage command line tool was not found at:"
+        echo $VBM
+        echo "Exiting"
+        exit
+    fi
+fi
 
 echo "Shutdown existing VM:s"
 ${VBM} controlvm Abitti-KTP poweroff 


### PR DESCRIPTION
The above-mentioned scripts work with minor changes on Mac OSX.
The only two things that seem to need to be changed are:
1) The directory location of the `VBoxManage` command-line tool on OSX and
2) Using `curl` instead of `wget` on OSX (OSX ships with `curl` but not `wget`)

Idea and PoC by Turo Sallinen, developing the same script to run on both Linux and OSX by Janne Cederberg. Tested and Conference to work by Turo Sallinen on OSX 10.13.4 (High Sierra).